### PR TITLE
fix for 'unsupported property on RestNewsChannel'

### DIFF
--- a/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
+++ b/src/Discord.Net.Rest/Entities/Channels/RestTextChannel.cs
@@ -42,7 +42,8 @@ namespace Discord.Rest
             base.Update(model);
             CategoryId = model.CategoryId;
             Topic = model.Topic.Value;
-            SlowModeInterval = model.SlowMode.Value;
+            if (model.SlowMode.IsSpecified)
+                SlowModeInterval = model.SlowMode.Value;
             IsNsfw = model.Nsfw.GetValueOrDefault();
         }
 


### PR DESCRIPTION
fix: https://github.com/discord-net/Discord.Net/issues/1436

`SlowModeInterval` property causes an exception for Announcement Channel feature if it is enabled on discord. Should be checked whether it is specified or not before set to property.